### PR TITLE
fix default bucket name for env list

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -56,7 +56,7 @@ apply_env () {
 check_preexisting_install () {
   if [ -d "$INSTALL_DIR" ] && [ -f "$BIN_FILE" ]; then
     echo "Found preexisting Terrabutler installation: $INSTALL_DIR."
-    
+
     if [ "${FORCE_INSTALL:-no}" == "yes" ] ; then
         echo "Replacing preexisting Terrabutler installation (FORCE_INSTALL=yes)"
         rm -rf "$INSTALL_DIR" "$BIN_FILE"

--- a/terrabutler/env.py
+++ b/terrabutler/env.py
@@ -131,7 +131,7 @@ def get_available_envs(s3):
         dev_env = boto3.session.Session(profile_name=f"{org}"
                                         f"-{default_env_name}")
         s3 = dev_env.resource("s3")
-        bucket = s3.Bucket(f"{org}-{default_env_name}-site-inception-tfstate")
+        bucket = s3.Bucket(f"{org}-{default_env_name}-site-inception")
 
         envs = []
 


### PR DESCRIPTION
fixes: #158 

before:
```
❯ terrabutler env list -s3
Traceback (most recent call last):
  File "terrabutler/__main__.py", line 5, in <module>
  File "click/core.py", line 1157, in __call__
  File "click/core.py", line 1078, in main
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1688, in invoke
  File "click/core.py", line 1434, in invoke
  File "click/core.py", line 783, in invoke
  File "terrabutler/click.py", line 101, in env_list_cli
  File "terrabutler/env.py", line 138, in get_available_envs
  File "boto3/resources/collection.py", line 81, in __iter__
  File "boto3/resources/collection.py", line 171, in pages
  File "botocore/paginate.py", line 269, in __iter__
  File "botocore/paginate.py", line 357, in _make_request
  File "botocore/client.py", line 553, in _api_call
  File "botocore/client.py", line 1009, in _make_api_call
botocore.errorfactory.NoSuchBucket: An error occurred (NoSuchBucket) when calling the ListObjects operation: The specified bucket does not exist
[PYI-274819:ERROR] Failed to execute script '__main__' due to unhandled exception!
```

after:
```
❯ terrabutler env list -s3
proj1
proj2
→ proj3
```